### PR TITLE
Initial build

### DIFF
--- a/.gitlab-ci.yaml
+++ b/.gitlab-ci.yaml
@@ -1,0 +1,19 @@
+stages:
+  - build
+
+build-push-master:
+  stage: build
+  script:
+    - make build
+    - make push
+  only:
+    refs:
+      - master
+
+build-push-tag:
+  stage: build
+  script:
+    - make build-tag
+    - make push-tag
+  only:
+    - tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM alpine:3.8
+
+ENV LOCUST_VERSION=0.9.0 \
+    LOCUST_USER=locust \
+    LOCUST_UID=10000 \
+    LOCUST_GROUP=locust \
+    LOCUST_GID=10000 \
+    LOCUST_HOME=/opt/locust \
+    LANG=C.UTF-8 \
+    LE_STAGING_URL=https://letsencrypt.org/certs/fakelerootx1.pem \
+    LE_STAGING_SHA=12ee1647b9e344a110771b98ebce1f245dda0cd1 \
+    LE_STAGING_FILE=/usr/local/share/ca-certificates/fakelerootx1.pem
+
+RUN apk add --update --no-cache \
+      ca-certificates \
+      openssl \
+      py3-zmq \
+      python3 \
+    && apk add --no-cache --update --virtual build-dependencies \
+      gcc \
+      musl-dev \
+      python3-dev \
+    && pip3 install locustio=="${LOCUST_VERSION}" \
+    && mkdir -p "${LOCUST_HOME}" \
+    && addgroup -g "${LOCUST_GID}" "${LOCUST_GROUP}" \
+    && adduser -g "Kafka user" -D -h "${LOCUST_HOME}" -G "${LOCUST_GROUP}" -s /sbin/nologin -u "${LOCUST_UID}" "${LOCUST_USER}" \
+    && chown -R "${LOCUST_USER}:${LOCUST_GROUP}" "${LOCUST_HOME}" \
+    && apk del build-dependencies \
+    && wget "${LE_STAGING_URL}" -O "${LE_STAGING_FILE}" \
+    && echo "${LE_STAGING_SHA}  ${LE_STAGING_FILE}" |  sha1sum -c -
+
+COPY entrypoint.sh /entrypoint.sh
+COPY locust-tasks /locust-tasks
+
+USER ${LOCUST_USER}
+WORKDIR ${LOCUST_HOME}
+
+EXPOSE 8089 \
+       5557 \
+       5558
+
+CMD ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --update --no-cache \
     && pip3 install locustio=="${LOCUST_VERSION}" \
     && mkdir -p "${LOCUST_HOME}" \
     && addgroup -g "${LOCUST_GID}" "${LOCUST_GROUP}" \
-    && adduser -g "Kafka user" -D -h "${LOCUST_HOME}" -G "${LOCUST_GROUP}" -s /sbin/nologin -u "${LOCUST_UID}" "${LOCUST_USER}" \
+    && adduser -g "Locust user" -D -h "${LOCUST_HOME}" -G "${LOCUST_GROUP}" -s /sbin/nologin -u "${LOCUST_UID}" "${LOCUST_USER}" \
     && chown -R "${LOCUST_USER}:${LOCUST_GROUP}" "${LOCUST_HOME}" \
     && apk del build-dependencies \
     && wget "${LE_STAGING_URL}" -O "${LE_STAGING_FILE}" \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: help build build-tag push 
+.DEFAULT_GOAL:= help
+.ONESHELL:
+
+DOCKER_IMAGE = gpii/locust
+
+help:                     ## Prints list of tasks
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' Makefile
+
+build:                    ## Build image as latest
+	docker build -t "${DOCKER_IMAGE}:latest" ./
+
+build-tag:                ## Build image as tag (use CI_COMMIT_TAG env var)
+	@CI_COMMIT_TAG="$${CI_COMMIT_TAG:?Required variable not set}"
+	docker build -t "${DOCKER_IMAGE}:${CI_COMMIT_TAG}" ./
+
+push:                     ## Push image - latest
+	docker push "${DOCKER_IMAGE}:latest"
+
+push-tag:                 ## Push image - tag
+	@CI_COMMIT_TAG="$${CI_COMMIT_TAG:?Required variable not set}"
+	docker push "${DOCKER_IMAGE}:${CI_COMMIT_TAG}"
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ image.
 Create and push git tag and CI will build and publish corresponding`
 `gpii/locust:${git_tag}` docker image.
 
+#### Tag format
+
+Tags should follow actual locust version, suffixed by
+`-gpii.${gpii_build_number}`, where `gpii_build_number` is monotonically
+increasing number denoting Docker image build number,  starting from `0`
+for each upstream version.
+
+Example:
+```
+0.9.0-gpii.0
+0.9.0-gpii.1
+0.9.0-gpii.2
+...
+0.9.1-gpii.0
+```
+
 ### Manually
 
 Run `make` to see all available steps.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # docker-image-locust
-Locust Docker image
+
+This images is based on Alpine and designed to be compatible with the Locust
+chart we use. It also adds certificates for Let's Encrypt Staging, as we use
+these for our dev environments.
+
+## Building
+
+### Master
+
+On push/merge to master, CI will automatically build and push `gpii/locust:latest`
+image.
+
+### Tags
+
+Create and push git tag and CI will build and publish corresponding`
+`gpii/locust:${git_tag}` docker image.
+
+### Manually
+
+Run `make` to see all available steps.
+
+- `make build` to build image as latest
+- `make push` to push this image to registry

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eo pipefail
+
+LOCUST_BIN='/usr/bin/locust'
+LOCUST_SCRIPT="${LOCUST_SCRIPT:-/locust-tasks/tasks.py}"
+LOCUST_MODE="${LOCUST_MODE:-standalone}"
+
+TARGET_HOST="${TARGET_HOST:?Required variable not set}"
+
+if [ "$LOCUST_MODE" == "master" ]; then
+  LOCUST_CMD="${LOCUST_BIN} -f ${LOCUST_SCRIPT} --host ${TARGET_HOST} --master"
+elif [[ "$LOCUST_MODE" = "worker" ]]; then
+  LOCUST_MASTER="${LOCUST_MASTER:?Required variable not set}"
+  LOCUST_CMD="${LOCUST_BIN} -f ${LOCUST_SCRIPT} --host ${TARGET_HOST} --slave --master-host=${LOCUST_MASTER}"
+    
+  # Wait for master
+  while ! wget --spider -qT5 "${LOCUST_MASTER}:${LOCUST_MASTER_WEB}" >/dev/null 2>&1; do
+    echo "Waiting for master..."
+    sleep 5
+  done
+else
+  LOCUST_CMD="${LOCUST_BIN} -f ${LOCUST_SCRIPT} --host ${TARGET_HOST}"
+fi
+
+echo "Executing locust command: ${LOCUST_CMD}"
+exec ${LOCUST_CMD}

--- a/locust-tasks/tasks.py
+++ b/locust-tasks/tasks.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import uuid
+
+from datetime import datetime
+from locust import HttpLocust, TaskSet, task
+
+
+class MetricsTaskSet(TaskSet):
+    _deviceid = None
+
+    def on_start(self):
+        self._deviceid = str(uuid.uuid4())
+
+    @task(1)
+    def login(self):
+        self.client.post(
+            '/login', {"deviceid": self._deviceid})
+
+    @task(999)
+    def post_metrics(self):
+        self.client.post(
+            "/metrics", {"deviceid": self._deviceid, "timestamp": datetime.now()})
+
+
+class MetricsLocust(HttpLocust):
+    task_set = MetricsTaskSet


### PR DESCRIPTION
Initial take on Locust image build. It follows the concept of the Locust chart we use, so it's compatible, swap-in replacement.

Notable differences:
- Adds Let's encrypt Staging certificates
- Uses latest version of Locust - 0.9.0
- Based on the latest Alpine 3.8
- Uses `locust` user (no root)
- No security issues (at least according to quay.io as of `22-01-2019`)
- Smaller size (`34 MB` instead of `42 MB`)

The new image has been tested using `rake test_flowmanager` and `rake test_preferences`.