### PR TITLE
GPII-3843: Add curl to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV LOCUST_VERSION=0.9.0 \
 
 RUN apk add --update --no-cache \
       ca-certificates \
+      curl \
       openssl \
       py3-zmq \
       python3 \


### PR DESCRIPTION
This adds curl to the docker image, in order to wait before the service is available in our locust tests. Related to [GPII-3843](https://issues.gpii.net/browse/GPII-3843).

Image should be tagged as `0.9.0-gpii.3`