### PR TITLE
GPII-3883: Wait for several successful responses before moving on

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eo pipefail
-[ "${DEBUG}" == 'true' ] && set -x
+[ "${DEBUG}" = 'true' ] && set -x
 
 LOCUST_BIN='/usr/bin/locust'
 LOCUST_SCRIPT="${LOCUST_SCRIPT:-/locust-tasks/tasks.py}"
@@ -12,24 +12,38 @@ WAIT_FOR_ENDPOINT="${WAIT_FOR_ENDPOINT:-/health}"
 WAIT_FOR_HTTP_CODE="${WAIT_FOR_HTTP_CODE:-200}"
 WAIT_FOR_SLEEP_TIME="${WAIT_FOR_SLEEP_TIME:-5}"
 WAIT_FOR_CURL_CMD="${WAIT_FOR_CURL_CMD:-curl -s -o /dev/null --max-time 1 -w %{http_code}}"
+WAIT_FOR_SUCCESS_THRESHOLD=${WAIT_FOR_SUCCESS_THRESHOLD:-5}
 
 TARGET_HOST="${TARGET_HOST:?Required variable not set}"
 
 # Wait for target service to become reachable from within the locust pod before starting the test
-CODE='null'
-if [ "${WAIT_FOR_TARGET}" == 'true' ]; then
+SUCCEEDED=0
+if [ "${WAIT_FOR_TARGET}" = 'true' ]; then
   echo "Waiting for http return code ${WAIT_FOR_HTTP_CODE} from ${TARGET_HOST}${WAIT_FOR_ENDPOINT}"
-  while [ "${CODE}" != "${WAIT_FOR_HTTP_CODE}" ]; do
-    CODE="$(${WAIT_FOR_CURL_CMD} "${TARGET_HOST}${WAIT_FOR_ENDPOINT}" || true)"
-    echo "Return code from ${TARGET_HOST}${WAIT_FOR_ENDPOINT} is ${CODE}"
-    # Sleep only if we're not done yet
-    [ "${CODE}" != "${WAIT_FOR_HTTP_CODE}" ] && sleep "${WAIT_FOR_SLEEP_TIME}"
+  # Wait for $WAIT_FOR_SUCCESS_THRESHOLD consecutive successes
+  while [ "${SUCCEEDED}" -lt "${WAIT_FOR_SUCCESS_THRESHOLD}" ]; do
+    CODE='null'
+    # Each time wait for expected return code
+    while [ "${CODE}" != "${WAIT_FOR_HTTP_CODE}" ]; do
+      CODE="$(${WAIT_FOR_CURL_CMD} "${TARGET_HOST}${WAIT_FOR_ENDPOINT}" || true)"
+
+      # Reset success counter if we've failed
+      if [ "${CODE}" != "${WAIT_FOR_HTTP_CODE}" ]; then
+        SUCCEEDED=0
+      else
+        SUCCEEDED=$((SUCCEEDED+1))
+      fi
+      echo "Return code from ${TARGET_HOST}${WAIT_FOR_ENDPOINT} is ${CODE} (${SUCCEEDED}/${WAIT_FOR_SUCCESS_THRESHOLD})"
+
+      # Sleep only if we're not done yet
+      [ "${CODE}" != "${WAIT_FOR_HTTP_CODE}" ] && sleep "${WAIT_FOR_SLEEP_TIME}"
+    done
   done
 fi
 
-if [ "$LOCUST_MODE" == 'master' ]; then
+if [ "$LOCUST_MODE" = 'master' ]; then
   LOCUST_CMD="${LOCUST_BIN} -f ${LOCUST_SCRIPT} --host ${TARGET_HOST} --master ${LOCUST_OPTS}"
-elif [ "$LOCUST_MODE" == 'worker' ]; then
+elif [ "$LOCUST_MODE" = 'worker' ]; then
   LOCUST_MASTER="${LOCUST_MASTER:?Required variable not set}"
   LOCUST_CMD="${LOCUST_BIN} -f ${LOCUST_SCRIPT} --host ${TARGET_HOST} --slave --master-host=${LOCUST_MASTER} ${LOCUST_OPTS}"
     


### PR DESCRIPTION
This PR adds additional `WAIT_FOR_SUCCESS_THRESHOLD` (defaults to `5`) variable to the wait loop to support waiting for multiple successful responses before moving on.

This is an attempt to solve the issue with a high number of failing CI builds because of the slow max_response_time after moving to the DNS challenge. The hypothesis behind is that not all instances of `nginx-ingress` are ready with the certificate by the time we start the locust test.

The image should be tagged as `0.9.0-gpii.5` after the merge.